### PR TITLE
etcd component init IsHealth check Get operation context set timeout

### DIFF
--- a/backend/gopkgs/components/etcdx/config.go
+++ b/backend/gopkgs/components/etcdx/config.go
@@ -1,10 +1,15 @@
 package etcdx
 
-import "fmt"
+import (
+	"fmt"
+	"github.com/go-kratos/kratos/v2/log"
+	"time"
+)
 
 type Config struct {
-	Host string `json:"host" yaml:"host"`
-	Port int    `json:"port" yaml:"port"`
+	Host    string `json:"host" yaml:"host"`
+	Port    int    `json:"port" yaml:"port"`
+	Timeout string `json:"timeout" yaml:"timeout"`
 }
 
 func (c *Config) SetDefault() {
@@ -19,4 +24,13 @@ func (c *Config) SetDefault() {
 
 func (c *Config) GetEntrypoint() string {
 	return fmt.Sprintf("%s:%d", c.Host, c.Port)
+}
+
+func (c *Config) GetTimeout() (timeout time.Duration) {
+	timeout, err := time.ParseDuration(c.Timeout)
+	if err != nil {
+		log.Info("etcd timeout parsed error: %v , apply default 3s", c.Timeout)
+		timeout = 3 * time.Second
+	}
+	return
 }

--- a/backend/gopkgs/components/etcdx/etcd.go
+++ b/backend/gopkgs/components/etcdx/etcd.go
@@ -67,7 +67,10 @@ func GetClient(ctx context.Context, keys ...string) *clientv3.Client {
 func IsHealth() (err error) {
 	globalClientMap.Range(func(key, value interface{}) bool {
 		client := value.(*clientv3.Client)
-		_, err = client.Get(context.Background(), "health")
+		config := globalConfigMap[key.(string)]
+		timeoutCtx, cancelFunc := context.WithTimeout(context.Background(), config.GetTimeout())
+		defer cancelFunc()
+		_, err = client.Get(timeoutCtx, "health")
 		if err != nil {
 			log.Errorf("etcd health check failed, client key: %s", key)
 			return false


### PR DESCRIPTION
## Link to an issue

hanlde issue11

## What

etcd config 添加了 timeout 配置， IsHealth 方法在 Get health key 的 context 添加对应的超时设置

## How

etcd config 添加属性以及方法，如果配置无效，则方法会返回默认值 3s，在IsHealth客户端调用前获取config，并调用其方法获取 timeout 配置，并最后根据 timeout 创建 context，传入 Get

## Screenshots

<!-- Please add screenshots if we need. -->

## How to test

config.yaml 添加对应的 timeout 配置，并停止 etcd 服务，程序将出现超时

## Checklist

- [x ] Link to an issue if it really related.
- [ x] At least describe what this PR does.
- [ x] Use `rebase` to confirm that current branch doesn't conflict with main branch.
- [ ] Unit tests. At least do not reduce the unit test coverage.
- [ ] Checked and updated `guidelines.md` which used to describe how to build, deploy and use DouTok.
